### PR TITLE
fix: 出力のバグを修正

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -10,7 +10,7 @@ inline void InitRand()
 	srand((int)time(NULL));
 }
 
-inline int random()
+inline int my_random()
 {
 	return rand() % 4;
 }
@@ -33,7 +33,7 @@ int main()
 	int rem_x, rem_y;
 	int PLAYER[2];
 	
-	vector<char> V;
+	vector<string> V;
 
 	InitRand();
 
@@ -47,19 +47,19 @@ int main()
 
 	for (i = 0; i < half_Y; i++) {
 		for (j = 0; j < half_X; j++) {
-			date[i][j] = sign(random());
+			date[i][j] = sign(my_random());
 		}
 	}
 
 	if (rem_x) {
 		for (i = 0; i < y; i++) {
-			date[i][half_X] = sign(random());
+			date[i][half_X] = sign(my_random());
 		}
 	}
 
 	if (rem_y) {
 		for (i = 0; i < x; i++) {
-			date[half_Y][i] = sign(random());
+			date[half_Y][i] = sign(my_random());
 		}
 	}
 
@@ -67,20 +67,20 @@ int main()
 
 	show(date, x, y);
 
-	V.push_back(y);
-	V.push_back(' ');
-	V.push_back(x);
-	V.push_back(':');
+	V.push_back(std::to_string(y));
+	V.push_back(" ");
+	V.push_back(std::to_string(x));
+	V.push_back(":");
 
 	for (i = 0; i < y; i++) {
 		for (j = 0; j < x; j++) {
-			V.push_back(date[i][j]);
-			V.push_back(' ');
+			V.push_back(std::to_string(date[i][j]));
+			V.push_back(" ");
 		}
-		V.push_back(':');
+		V.push_back(":");
 	}
 
-	for (i = 0; i < 69; i++) {
+	for (i = 0; i < V.size(); i++) {
 		cout << V[i];
 	}
 


### PR DESCRIPTION
出力データを記憶しておくstd::vectorの型がcharになっていると、1文字しか扱えず、正しくデータを吐き出すことが出来ないので、charからstd::stringに変更した。また、
```cpp
using namespace std;
```
を使うことでstd::randomと関数のrandomが衝突するのでrandom関数をmy_random関数にリネームした。

また、最後の出力のforループの範囲をvectorのサイズとした。